### PR TITLE
Fix multiselect handling for contenidos transversales

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,9 +412,6 @@
             } else if (type === 'tiposEvaluacion') {
                 title = 'Seleccionar Tipos de Evaluación';
                 options = config.appData.tiposEvaluacion;
-            } else if (type === 'contenidosTransversales') {
-                title = 'Seleccionar Contenidos Transversales';
-                options = config.appData.contenidosTransversales;
             } else if (type === 'unidadDidactica') {
                 title = 'Seleccionar Unidad(es) Didáctica(s)';
                 options = config.appData.unidadesDidacticas;
@@ -775,7 +772,7 @@
             };
 
             for (const key in data) {
-                if (['materia', 'curso', 'sesionNum', 'tiposEvaluacion', 'contenidosTransversales', 'unidadDidactica'].includes(key)) {
+                if (['materia', 'curso', 'sesionNum', 'tiposEvaluacion', 'unidadDidactica'].includes(key)) {
                     const values = parseArrayData(data[key]);
                     document.getElementById(key).value = JSON.stringify(values);
                     ui.updateChipsDisplay(key, values);
@@ -954,7 +951,7 @@
             const data = { id: state.currentSessionId };
             
             const formFields = ['fecha', 'competenciaEspecifica', 'descriptoresOperativos', 'competenciasClave'];
-            const multiSelectFields = ['materia', 'curso', 'sesionNum', 'tiposEvaluacion', 'contenidosTransversales', 'contenidos', 'unidadDidactica'];
+            const multiSelectFields = ['materia', 'curso', 'sesionNum', 'tiposEvaluacion', 'unidadDidactica'];
             const editorFields = config.allEditorIds;
 
             // Get values from simple form fields


### PR DESCRIPTION
## Summary
- Remove unsupported multiselect modal for `contenidosTransversales`
- Limit multiselect processing to fields managed by modal selectors

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85484d6d483229b51e59cf64e4838